### PR TITLE
Make RG regex less inclusive

### DIFF
--- a/expressions.cfg
+++ b/expressions.cfg
@@ -3,7 +3,7 @@ ENDERECO_DATA;DM_ENDERECO;true;'(^[Rr][.]?([Uu][Aa])?[\\s].*$)|(^[Aa][.]?([Vv][E
 CEP_DATA;DM_CEP;true;'\\b([0-9]{5})-([0-9]{3})\\b'
 NOME_DATA;DM_NOME;true;'^(?![\\s])(?!.*[\\s]{2})((?:e|da|do|das|dos|de|d'|D'|la|las|el|los)\\s*?|(?:[A-Z][^\\s]*\\s*?)(?!.*[\\s]$))+$'
 CPFCNPJ_DATA;DM_CPFCNPJ;true;'^([0-9]{2}[\\.]?[0-9]{3}[\\.]?[0-9]{3}[\\/]?[0-9]{4}[-]?[0-9]{2})|([0-9]{3}[\.]?[0-9]{3}[\\.]?[0-9]{3}[-]?[0-9]{2})$'
-RG_DATA;DM_RG;true;^[0-9]{2}[.]?[0-9]{3}[.]?[0-9]{3}[-]?([0-9]{1})?[Xx]?$
+RG_DATA;DM_RG;true;^(\d{2}\x2E\d{3}\x2E\d{3}[-]\d{1})$|^(\d{2}\x2E\d{3}\x2E\d{3})$
 TELEFONE_DATA;DM_TELEFONE;true;'^((\\+)?55)?[\\s]?[\\(]?(68)?(82)?(96)?(92)?(71)?(88)?(61)?(27)?(62)?(98)?(65)?(84)?(31)?(41)?(83)?(91)?(81)?(86)?(21)?(84)?(51)?(69)?(95)?(48)?(79)?(11)?(63)?[\\)]?[\\s]?(?:[2-8]|9[1-9])[0-9]{3}(\\-)?[0-9]{4}$'
 NOME_METADATA;DM_NOME;false;(^([Pp][Rr][Ii][Mm][Ee][Ii][Rr][Oo])?([UuúÚ][Ll][Tt][Ii][Mm][Oo])?[^A-Za-z0-9]?[Nn][Oo][Mm][Ee]$)|(^[Ss][Oo][Bb][Rr][Ee][Nn][Oo][Mm][Ee]$)
 ENDERECO_METADATA;DM_ENDERECO;false;(.*[Ee][Nn][Dd][Ee][Rr][Ee][CcçÇ][Oo].*)


### PR DESCRIPTION
Make RG regex less inclusive and only validate RG if the numbers are split by `.` and `- ` .
This would raise less false positives and fix #1