### PR TITLE
ENDERECO_DATA

### DIFF
--- a/expressions.cfg
+++ b/expressions.cfg
@@ -1,5 +1,5 @@
 # Expression Name;Domain Name;DataLevel(True|False);Regex
-ENDERECO_DATA;DM_ENDERECO;true;'(^[Rr][.]?([Uu][Aa])?[\\s].*$)|(^[Aa][.]?([Vv][Ee][Nn][Ii][Dd][Aa])?.*$)|(^[Aa][Ll][.]?([Aa][Mm][Ee][Dd][Aa])?.*$)|(^[Qq][Uu][Aa][Dd][Rr][Aa].*$)|(^[Tr][Rr][Aa][Vv][.]?([Ee][Ss]{2}[Aa])?.*)|(^[Pp][Rr][Aa][CcÇç][Aa].*)|(^[Ee][Ss][Tt][Rr][Aa][Dd][Aa].*)|(^[Rr][Oo][Dd][Oo][Vv][Ii][Aa].*)'
+ENDERECO_DATA;DM_ENDERECO;true;'^(RUA|Rua|rua|R\.|AVENIDA|Avenida|avenida|av|AV\.|TRAVESSA|Travessa|TRAV\.|Trav\.|rodovia|RODOVIA|Rodovia|Rod\.)\s?([a-zA-Z_\s]+)[, ]*+(\d+)*\s?([-\/\d\sa-zDA-Z]+)?$'
 CEP_DATA;DM_CEP;true;'\\b([0-9]{5})-([0-9]{3})\\b'
 NOME_DATA;DM_NOME;true;'^(?![\\s])(?!.*[\\s]{2})((?:e|da|do|das|dos|de|d'|D'|la|las|el|los)\\s*?|(?:[A-Z][^\\s]*\\s*?)(?!.*[\\s]$))+$'
 CPFCNPJ_DATA;DM_CPFCNPJ;true;'^([0-9]{2}[\\.]?[0-9]{3}[\\.]?[0-9]{3}[\\/]?[0-9]{4}[-]?[0-9]{2})|([0-9]{3}[\.]?[0-9]{3}[\\.]?[0-9]{3}[-]?[0-9]{2})$'


### PR DESCRIPTION
while the previous format was to strict in some aspects (obligatory numbers, couldn't have more than one space after number), it was also to open in other aspects (client Dafiti had a match because some marketing codes always started with "ad-").

This change will fix that.